### PR TITLE
PP-8512: Archive notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Pay Partner Integrations
 
+> As of September 2021 this repository is no longer actively maintained by the GOV.UK Pay team.
+
 Integrations in to GOV.UK Pay produced by partners including some from our January hack day and subsequent collected efforts.
 
 Please feel free to raise a pull request to put your own solution in to a directory, complete or incomplete, working or not working.


### PR DESCRIPTION
This repository has had no activity for 5 years (aside from the recent detect-secrets commit). It was used for collecting the results of a hack day in January 2016.

Archiving as part of our efforts to streamline Pay's repositories.